### PR TITLE
UMBC #83: Fixed Skills Autonomous Time

### DIFF
--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -46,7 +46,7 @@ class Robot {
     static constexpr char* skills_autonomous_file_partner = (char*)"/usd/autonomous_skills-partner.bin";
 
     static constexpr uint32_t match_autonomous_time_ms = 45000;
-    static constexpr uint32_t skills_autonomous_time_ms = 75000;
+    static constexpr uint32_t skills_autonomous_time_ms = 60000;
     static constexpr uint32_t opcontrol_delay_ms = 10;
 
     umbc::competition competition;


### PR DESCRIPTION
Fixed the autonomous skills time so that it is 60 seconds instead of 75 seconds.