### PR TITLE
UMBC #86 - End Opcontrol Task

### DIFF
--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -172,12 +172,11 @@ class Robot {
 	void opcontrol_stop(void);
 
     /**
-     * Checks if opcontrol task is currently recording.
+     * Checks if opcontrol task is on the ready, blocked, suspended or event lists.
      * 
-     * \return 1 if opcontrol task is running, otherwise 0
+     * \return 1 if opcontrol task is on the ready, blocked, suspended or event lists, otherwise 0
      */
-    std::int32_t opcontrol_isRunning();
-
+    std::int32_t opcontrol_isListed();
 };
 }
 

--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -40,6 +40,8 @@ typedef enum {
 class Robot {
     
     private:
+    static constexpr char* t_opcontrol_name =  (char*)"robot_opcontrol";
+
     static constexpr char* match_autonomous_file_master = (char*)"/usd/autonomous_match.bin";
     static constexpr char* match_autonomous_file_partner = (char*)"/usd/autonomous_match-partner.bin";
     static constexpr char* skills_autonomous_file_master = (char*)"/usd/autonomous_skills.bin";
@@ -60,6 +62,8 @@ class Robot {
 
     umbc::Controller* controller_master = &vcontroller_master;
     umbc::Controller* controller_partner = &pcontroller_partner;
+
+    std::unique_ptr<Task> t_opcontrol;
 
     /**
      * Menu to select the competition type using the LLEMU.
@@ -144,6 +148,36 @@ class Robot {
      * \param record_partner_controller - Set to true if the partner controller should be recorded.
      */
     void train_autonomous(uint32_t record_partner_controller);
+
+    /**
+     * Starts opcontrol task.
+     */
+	void opcontrol_start(void);
+
+    /**
+     * Pauses opcontrol task if opcontrol task is currently
+     * active.
+     */
+	void opcontrol_pause(void);
+
+    /**
+     * Resumes opcontrol task if opcontrol task is currently
+     * paused.
+     */
+	void opcontrol_resume(void);
+
+    /**
+     * Stops opcontrol task.
+     */
+	void opcontrol_stop(void);
+
+    /**
+     * Checks if opcontrol task is currently recording.
+     * 
+     * \return 1 if opcontrol task is running, otherwise 0
+     */
+    std::int32_t opcontrol_isRunning();
+
 };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ void disabled() {
 	pros::lcd::clear();
 	pros::lcd::set_text(1, "Robot Disabled");
 
-	if (robot.opcontrol_isRunning()) {
+	if (robot.opcontrol_isListed()) {
 		robot.opcontrol_stop();
 	}
 
@@ -110,7 +110,7 @@ void autonomous() {
  */
 void opcontrol() {
 
-	if (robot.opcontrol_isRunning()) {
+	if (robot.opcontrol_isListed()) {
 		robot.opcontrol_stop();
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,10 @@ void disabled() {
 	pros::lcd::clear();
 	pros::lcd::set_text(1, "Robot Disabled");
 
+	if (robot.opcontrol_isRunning()) {
+		robot.opcontrol_stop();
+	}
+
 	INFO("robot disabled");
 }
 
@@ -105,6 +109,10 @@ void autonomous() {
  * task, not resume it from where it left off.
  */
 void opcontrol() {
+
+	if (robot.opcontrol_isRunning()) {
+		robot.opcontrol_stop();
+	}
 
 	while (1) {
 		pros::lcd::clear();

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -320,7 +320,7 @@ void umbc::Robot::opcontrol_resume() {
 void umbc::Robot::opcontrol_stop() {
 
     Task* t_opcontrol = this->t_opcontrol.get();
-
+    
     if (nullptr != t_opcontrol) {
         try {
             t_opcontrol->remove();
@@ -331,9 +331,10 @@ void umbc::Robot::opcontrol_stop() {
     }
 }
 
-std::int32_t umbc::Robot::opcontrol_isRunning() {
+std::int32_t umbc::Robot::opcontrol_isListed() {
 
     Task* t_opcontrol = this->t_opcontrol.get();
 
-    return (nullptr == t_opcontrol) ? 0 : t_opcontrol->get_state() == E_TASK_STATE_RUNNING;
+    return (nullptr == t_opcontrol) ? 0 
+        : ((t_opcontrol->get_state() != E_TASK_STATE_INVALID) && (t_opcontrol->get_state() != E_TASK_STATE_DELETED));
 }


### PR DESCRIPTION
Added the opcontrol task for the Robot class as a data member. This allows for the task to be deleted when the robot is disabled and to prevent the virtual controller from continuing to run during normal opcontrol operation.