### PR TITLE
UMBC #98: Added a Config File Setting LF as EOL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8


### PR DESCRIPTION
Added a config file to set the line ending for the project to LF to make development more uniform when developing on different operating systems.